### PR TITLE
Configure migrations to use appsettings.Development

### DIFF
--- a/ExampleProject/Migrations/DesignTimeDbContextFactory.cs
+++ b/ExampleProject/Migrations/DesignTimeDbContextFactory.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace YourApp.Migrations
+{
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext(string[] args)
+        {
+            // Force Development environment for design-time operations
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+            
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false)
+                .AddJsonFile("appsettings.Development.json", optional: false)
+                .Build();
+
+            var connectionString = configuration.GetConnectionString("DefaultConnection");
+            
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            optionsBuilder.UseSqlServer(connectionString);
+
+            return new ApplicationDbContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/ExampleProject/Program.cs
+++ b/ExampleProject/Program.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Force Development environment for migrations
+Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+
+// Add services to the container
+builder.Services.AddControllers();
+
+// Configure Entity Framework with Development settings
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+{
+    var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+    options.UseSqlServer(connectionString);
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline
+if (app.Environment.IsDevelopment())
+{
+    app.UseDeveloperExceptionPage();
+}
+
+app.UseRouting();
+app.MapControllers();
+
+app.Run();
+
+public class ApplicationDbContext : DbContext
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
+    {
+    }
+
+    // Add your DbSets here
+    // public DbSet<YourEntity> YourEntities { get; set; }
+}

--- a/ExampleProject/README-Migrations.md
+++ b/ExampleProject/README-Migrations.md
@@ -1,0 +1,63 @@
+# .NET Migrations Always Using Development Settings
+
+This project is configured to ensure that Entity Framework migrations always use `appsettings.Development.json` settings.
+
+## Configuration Methods
+
+### Method 1: Environment Variable (Recommended)
+The `Program.cs` file sets the environment variable to force Development mode:
+```csharp
+Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+```
+
+### Method 2: DesignTimeDbContextFactory
+The `Migrations/DesignTimeDbContextFactory.cs` file ensures that design-time operations (like creating migrations) always use Development settings.
+
+### Method 3: Scripts
+Use the provided scripts in the `scripts/` folder:
+
+#### Linux/Mac:
+```bash
+# Add a new migration
+./scripts/add-migration-dev.sh InitialCreate
+
+# Apply migrations
+./scripts/migrate-dev.sh
+```
+
+#### Windows:
+```cmd
+# Add a new migration
+scripts\add-migration-dev.bat InitialCreate
+
+# Apply migrations
+scripts\migrate-dev.bat
+```
+
+## Manual Commands
+
+If you prefer to run commands manually, always set the environment variable first:
+
+### Linux/Mac:
+```bash
+export ASPNETCORE_ENVIRONMENT=Development
+dotnet ef migrations add InitialCreate
+dotnet ef database update
+```
+
+### Windows:
+```cmd
+set ASPNETCORE_ENVIRONMENT=Development
+dotnet ef migrations add InitialCreate
+dotnet ef database update
+```
+
+## Verification
+
+To verify that migrations are using Development settings, check the connection string in your `appsettings.Development.json` file. The database name should reflect your Development configuration.
+
+## Important Notes
+
+1. **Always use Development environment for migrations** - This prevents accidentally running migrations against production databases.
+2. **DesignTimeDbContextFactory is crucial** - It ensures that `dotnet ef` commands use the correct configuration.
+3. **Environment variables override** - Setting `ASPNETCORE_ENVIRONMENT=Development` ensures the correct appsettings file is loaded.

--- a/ExampleProject/YourApp.csproj
+++ b/ExampleProject/YourApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/ExampleProject/appsettings.Development.json
+++ b/ExampleProject/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=YourAppDb_Dev;Trusted_Connection=true;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Information"
+    }
+  }
+}

--- a/ExampleProject/appsettings.json
+++ b/ExampleProject/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=YourAppDb_Prod;Trusted_Connection=true;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/ExampleProject/scripts/add-migration-dev.bat
+++ b/ExampleProject/scripts/add-migration-dev.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Script to add new migrations with Development environment
+REM This ensures migrations always use appsettings.Development.json
+
+if "%1"=="" (
+    echo Usage: %0 ^<migration-name^>
+    echo Example: %0 InitialCreate
+    exit /b 1
+)
+
+echo Setting environment to Development for migration creation...
+set ASPNETCORE_ENVIRONMENT=Development
+
+echo Adding new migration: %1
+dotnet ef migrations add "%1" --project ..\YourApp.csproj --startup-project ..\YourApp.csproj
+
+echo Migration '%1' created using Development settings.
+pause

--- a/ExampleProject/scripts/add-migration-dev.sh
+++ b/ExampleProject/scripts/add-migration-dev.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Script to add new migrations with Development environment
+# This ensures migrations always use appsettings.Development.json
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <migration-name>"
+    echo "Example: $0 InitialCreate"
+    exit 1
+fi
+
+echo "Setting environment to Development for migration creation..."
+export ASPNETCORE_ENVIRONMENT=Development
+
+echo "Adding new migration: $1"
+dotnet ef migrations add "$1" --project ../YourApp.csproj --startup-project ../YourApp.csproj
+
+echo "Migration '$1' created using Development settings."

--- a/ExampleProject/scripts/migrate-dev.bat
+++ b/ExampleProject/scripts/migrate-dev.bat
@@ -1,0 +1,12 @@
+@echo off
+REM Script to run migrations with Development environment
+REM This ensures migrations always use appsettings.Development.json
+
+echo Setting environment to Development for migrations...
+set ASPNETCORE_ENVIRONMENT=Development
+
+echo Running Entity Framework migrations...
+dotnet ef database update --project ..\YourApp.csproj --startup-project ..\YourApp.csproj
+
+echo Migrations completed using Development settings.
+pause

--- a/ExampleProject/scripts/migrate-dev.sh
+++ b/ExampleProject/scripts/migrate-dev.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Script to run migrations with Development environment
+# This ensures migrations always use appsettings.Development.json
+
+echo "Setting environment to Development for migrations..."
+export ASPNETCORE_ENVIRONMENT=Development
+
+echo "Running Entity Framework migrations..."
+dotnet ef database update --project ../YourApp.csproj --startup-project ../YourApp.csproj
+
+echo "Migrations completed using Development settings."


### PR DESCRIPTION
Configure .NET migrations to always use `appsettings.Development` to ensure consistent development environment setup and prevent accidental production database changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-5759d0a1-f047-47bb-ad70-a3274112c701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5759d0a1-f047-47bb-ad70-a3274112c701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

